### PR TITLE
Update solver.py : from jax import config is deprecated (fails installation for newer versions of jax)

### DIFF
--- a/helens/solver.py
+++ b/helens/solver.py
@@ -5,8 +5,8 @@ __author__ = 'austinpeel', 'aymgal'
 
 
 import jax.numpy as jnp
-from jax.config import config
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 
 class LensEquationSolver(object):


### PR DESCRIPTION
The current version fails pip installation with a newer version of jax (tested with 0.4.25).

The supported format for newer versions of jax is to use import jax and then using jax.config to update the configuration.

Changing 
```
from jax import config
config.update(...)
```

to the recommended form:
```
import jax
jax.config.update(...)
```

in `solver.py` fixes the installation problem.